### PR TITLE
[BUGFIX] Fix crash when retriving thumbstickToMouseModifier.

### DIFF
--- a/Overrides/NewGame1.cs
+++ b/Overrides/NewGame1.cs
@@ -261,11 +261,11 @@ namespace SpaceCore.Overrides
                 {
                     double x1 = (double)state2.X;
                     thumbSticks = state3.ThumbSticks;
-                    double num1 = (double)thumbSticks.Right.X * (double)Reflect.getField<float>(typeof(Game1), "thumbstickToMouseModifier");
+                    double num1 = (double)thumbSticks.Right.X * (double)Reflect.callMethod<float>(typeof(Game1), "get_thumbstickToMouseModifier", new object[0]);
                     int x2 = (int)(x1 + num1);
                     double y1 = (double)state2.Y;
                     thumbSticks = state3.ThumbSticks;
-                    double num2 = (double)thumbSticks.Right.Y * (double)Reflect.getField<float>(typeof(Game1), "thumbstickToMouseModifier");
+                    double num2 = (double)thumbSticks.Right.Y * (double)Reflect.callMethod<float>(typeof(Game1), "get_thumbstickToMouseModifier", new object[0]);
                     int y2 = (int)(y1 - num2);
                     Mouse.SetPosition(x2, y2);
                     Game1.lastCursorMotionWasMouse = false;


### PR DESCRIPTION
Fix issue [#1](https://github.com/spacechase0/CookingSkill/issues/1) reported in CookingSkill repo.