### PR TITLE
Milestone commit 2021-04-01:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Magic
+# SpaceCore
 This is the source code. Releases can be found at:
-* [My site](http://spacechase0.com/mods/stardew-valley/magic)
+* [My site](http://spacechase0.com/mods/stardew-valley/spacecore)
 * [Nexus]()
 * [Chucklefish forums]()


### PR DESCRIPTION
- Merge various changes required to be content-complete for Stardew Valley 1.5.
- Add behaviour to handle profession repicking from sewer shrine re: CustomSkills, Professions.
Previously users are unable to change professions without console commands.
- Changes to take advantage of new SMAPI features added since SMAPI 3.9.5, aiming to deal with more efficient memory management.
- Resolve conflicts between serialisers for both SpaceCore and Ento Framework: serialisers pattern-match expected types and defer to one-another when required.
Must await changes merged into Ento Framework before release.
- Prepare SpaceCore for 64-bit readiness.
Should fix out-of-memory issues native to SpaceCore, which apparently began occurring after latest release added a texture asset.
- Migrate SpaceCore to XML project and resolve x32/Any target configuration.